### PR TITLE
Add automated docs build checks and surface live documentation links

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,39 @@
+name: Docs Build Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-build.yml'
+      - 'README.md'
+      - 'wiki/**'
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    name: Verify Jekyll site builds
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Build documentation site
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build --destination _site --strict_front_matter
+
+      - name: Doctor site configuration
+        run: bundle exec jekyll doctor

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # CPA Advisory Platform MVP
 
-A comprehensive multi-tenant SaaS platform built for CPAs to manage clients, sync with QuickBooks, and provide financial advisory services.
+AdvisorOS is a production-ready, multi-tenant SaaS platform that unifies client management, workflow automation, and revenue intelligence for modern CPA firms.
+
+## Executive Summary
+
+- **Mission:** Give CPA teams a single operating system that merges QuickBooks data, automated compliance workflows, and advisory insights so they can scale beyond traditional bookkeeping.
+- **Core Outcomes:** Streamlined client onboarding, proactive revenue analytics, secure document collaboration, and audit-ready controls baked into every release.
+- **How to Explore:** Start with the live documentation portal, branch into the curated wiki for process snapshots, then dive into the repo for implementation detail.
+
+## Documentation & Knowledge Base
+
+- **Live Docs (GitHub Pages):** [https://markusahling.github.io/AdvisorOS/](https://markusahling.github.io/AdvisorOS/) – Built with the Just-the-Docs theme and continuously validated in CI to guarantee a clean deploy.
+- **Knowledge Wiki:** [AdvisorOS Overview](https://github.com/MarkusAhling/AdvisorOS/wiki/Overview) – Mirrors the executive summary and links back to the docs portal so stakeholders never have to browse raw markdown files.
+- **Source Repository:** [GitHub](https://github.com/MarkusAhling/AdvisorOS) – Use structured PRs and the docs build workflow to keep the public site green.
 
 ## 🏗️ Architecture
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.6.2"
+gem "webrick", "~> 1.8"
+
+group :jekyll_plugins do
+  gem "jekyll-remote-theme", "~> 0.4.3"
+  gem "jekyll-sitemap", "~> 1.4"
+  gem "jekyll-feed", "~> 0.17"
+  gem "jekyll-seo-tag", "~> 2.8"
+end

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,10 +1,20 @@
 title: AdvisorOS Documentation
 description: Implementation, adoption, and operations playbook for AdvisorOS.
 remote_theme: just-the-docs/just-the-docs
+theme: just-the-docs
 search_enabled: true
 color_scheme: dark
 enable_copy_code_button: true
 heading_anchors: true
+
+url: https://markusahling.github.io
+baseurl: /AdvisorOS
+
+plugins:
+  - jekyll-remote-theme
+  - jekyll-sitemap
+  - jekyll-feed
+  - jekyll-seo-tag
 
 aux_links:
   "AdvisorOS on GitHub": "https://github.com/MarkusAhling/AdvisorOS"
@@ -12,6 +22,9 @@ aux_links:
 nav_external_links:
   - title: Product Overview (PDF)
     url: https://github.com/MarkusAhling/AdvisorOS/blob/main/ADVISOROS_COMPREHENSIVE_ENHANCEMENT_PORTFOLIO.md
+    open_in_new_tab: true
+  - title: AdvisorOS Knowledge Wiki
+    url: https://github.com/MarkusAhling/AdvisorOS/wiki
     open_in_new_tab: true
 
 callouts:

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,0 +1,23 @@
+# AdvisorOS Overview
+
+AdvisorOS is a production-ready, multi-tenant SaaS platform that unifies client management, workflow automation, and revenue intelligence for modern CPA firms.
+
+## Why AdvisorOS Matters
+
+- **Mission:** Give CPA teams a single operating system that merges QuickBooks data, automated compliance workflows, and advisory insights so they can scale beyond traditional bookkeeping.
+- **Core Outcomes:** Streamlined client onboarding, proactive revenue analytics, secure document collaboration, and audit-ready controls baked into every release.
+- **How to Explore:** Start with the live documentation portal, branch into this wiki for distilled playbooks, then dive into the repository for implementation detail.
+
+## Quick Links
+
+- [Live Documentation Portal](https://markusahling.github.io/AdvisorOS/) — Full product, architecture, and operations playbooks built with the Just-the-Docs theme.
+- [Repository README](../README.md) — Deeper technical onboarding, scripts, and deployment guides.
+- [Issue Tracker](https://github.com/MarkusAhling/AdvisorOS/issues) — Log enhancements, bugs, or documentation updates.
+
+> 💡 **Tip:** Every page in this wiki should link back to the documentation portal or README so contributors never have to hunt through raw markdown files.
+
+## Contributing to the Wiki
+
+1. Create or update pages under the repository's Wiki tab.
+2. Ensure each page cross-links to the [live documentation](https://markusahling.github.io/AdvisorOS/) and relevant repo resources.
+3. Run the Docs Build Quality Gate workflow locally or via PR when touching markdown to keep the public site green.


### PR DESCRIPTION
## Summary
- document the live GitHub Pages portal and knowledge base pathways in the README and wiki
- configure the Just-the-Docs site with explicit plugins, site metadata, and Gemfile dependencies for local and CI builds
- add a GitHub Actions workflow that validates the documentation build on relevant pull requests

## Testing
- bundle install *(fails: 403 Forbidden when reaching rubygems.org in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dadf8ad780832ba63a20d851d3c0b6